### PR TITLE
Do not use EOS.undent

### DIFF
--- a/elasticsearch@1.7.rb
+++ b/elasticsearch@1.7.rb
@@ -67,7 +67,7 @@ class ElasticsearchAT17 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/
@@ -77,7 +77,7 @@ class ElasticsearchAT17 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch@1.7/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">


### PR DESCRIPTION
I tried installing this today and got the following error:

```
==> Installing elasticsearch@1.7 from brianatgood/elasticsearch17-tap
==> Downloading https://download.elastic.co/elasticsearch/elasticsearch/elastics
######################################################################## 100.0%
Error: Failed to install plist file
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/brianatgood/homebrew-elasticsearch17-tap/elasticsearch@1.7.rb:75:in `caveats'
```

Here's my current ruby version:

```
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin16]
```

This PR just applies the change requested from the error output.